### PR TITLE
Always allow setting page 1 when there are no results

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -120,7 +120,7 @@ class Pagerfanta implements PagerfantaInterface
         }
 
         // out of range pages
-        if (!$allowOutOfRangePages) {
+        if (!$allowOutOfRangePages && $currentPage > 1) {
             if ($currentPage > $this->getNbPages()) {
                 if (!$normalizeOutOfRangePages) {
                     throw new OutOfRangeCurrentPageException();


### PR DESCRIPTION
Because we don't want to add extra logic to userland when the results
are empty.
