### PR TITLE
Fixed the DoctrineORMAdapter

### DIFF
--- a/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
+++ b/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
@@ -101,10 +101,10 @@ class DoctrineORMAdapter implements AdapterInterface
 
             $ids = array_map('current', $subQuery->getScalarResult());
 
+            $whereInQuery = $this->cloneQuery($this->query);
             // don't do this for an empty id array
             if (count($ids) > 0) {
                 $namespace = 'pg_';
-                $whereInQuery = $this->cloneQuery($this->query);
 
                 $whereInQuery->setHint(Query::HINT_CUSTOM_TREE_WALKERS, array('Pagerfanta\Adapter\DoctrineORM\WhereInWalker'));
                 $whereInQuery->setHint('id.count', count($ids));
@@ -114,14 +114,12 @@ class DoctrineORMAdapter implements AdapterInterface
                     $i++;
                     $whereInQuery->setParameter("{$namespace}_{$i}", $id);
                 }
-            } else {
-                $whereInQuery = $this->query;
             }
 
             return $whereInQuery->getResult($this->query->getHydrationMode());
         }
 
-        return $this->query
+        return $this->cloneQuery($this->query)
             ->setMaxResults($length)
             ->setFirstResult($offset)
             ->getResult($this->query->getHydrationMode())

--- a/tests/Pagerfanta/Tests/Adapter/DoctrineORMAdapterTest.php
+++ b/tests/Pagerfanta/Tests/Adapter/DoctrineORMAdapterTest.php
@@ -78,4 +78,14 @@ class DoctrineORMAdapterTest extends DoctrineORMTestCase
         $this->assertEquals(2, count( $adapter->getSlice(0, 10)) );
         $this->assertEquals(1, count( $adapter->getSlice(1, 1)) );
     }
+
+    public function testCountAfterSlice()
+    {
+        $dql = "SELECT u FROM Pagerfanta\Tests\Adapter\DoctrineORM\User u";
+        $query = $this->entityManager->createQuery($dql);
+
+        $adapter = new DoctrineORMAdapter($query);
+        $adapter->getSlice(0, 1);
+        $this->assertEquals(2, $adapter->getNbResults() );
+    }
 }


### PR DESCRIPTION
This fixes the issue reported as whiteoctober/WhiteOctoberPagerfantaBundle#6

The issue was that a query cannot be modified once it is executed, and so the count query failed when the slice already occured. Now the query is cloned to execute the slice to keep the original query in a clean state.
