### PR TITLE
Added NullAdapter for generic use of the pager

### DIFF
--- a/src/Pagerfanta/Adapter/NullAdapter.php
+++ b/src/Pagerfanta/Adapter/NullAdapter.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the Pagerfanta package.
+ *
+ * (c) Pablo Díez <pablodip@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pagerfanta\Adapter;
+
+/**
+ * NullAdapter.
+ *
+ * @author Benjamin Dulau <benjamin.dulau@anonymation.com>
+ *
+ */
+class NullAdapter implements AdapterInterface
+{
+    private $nbResults;
+
+    /**
+     * Constructor.
+     *
+     * @param integer $nbResults Total item count.
+     *
+     * @api
+     */
+    public function __construct($nbResults = 0)
+    {
+        $this->nbResults = (int)$nbResults;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNbResults()
+    {
+        return $this->nbResults;
+    }
+
+    /**
+     * The following methods are derived from code of the Zend Framework
+     * Code subject to the new BSD license (http://framework.zend.com/license/new-bsd).
+     *
+     * Copyright (c) 2005-2010 Zend Technologies USA Inc. (http://www.zend.com)
+     *
+     * {@inheritdoc}
+     *
+     */
+    public function getSlice($offset, $length)
+    {
+        if ($offset >= $this->getNbResults()) {
+            return array();
+        }
+
+        $remainItemCount  = $this->getNbResults() - $offset;
+        $currentItemCount = $remainItemCount > $length ? $length : $remainItemCount;
+
+        return array_fill(0, $currentItemCount, null);
+    }
+}

--- a/tests/Pagerfanta/Tests/Adapter/NullAdapterTest.php
+++ b/tests/Pagerfanta/Tests/Adapter/NullAdapterTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Pagerfanta\Tests\Adapter;
+
+use Pagerfanta\Adapter\NullAdapter;
+
+class NullAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    protected $nbResults;
+    protected $adapter;
+
+    protected function setUp()
+    {
+        $this->nbResults = 33;
+        $this->adapter = new NullAdapter($this->nbResults);
+    }
+
+    public function testGetNbResults()
+    {
+        $this->assertSame(33, $this->adapter->getNbResults());
+    }
+
+    public function testGetResults()
+    {
+        $this->assertSame(array_fill(0, 10, null), $this->adapter->getSlice(20, 10));
+    }
+
+    public function testGetResultsWithRemainCountLessThanLength()
+    {
+        $this->assertSame(array_fill(0, 3, null), $this->adapter->getSlice(30, 10));
+    }
+
+}


### PR DESCRIPTION
Useful when the pager is only used for rendering and not retrieving items (e.g : when searching in an index like Solr).

However, can one of you run the unit tests ? I can't today, some problems with PHPUnit.

Thanks !
