### PR TITLE
Enforce the limit to be reset in get query :

### DIFF
--- a/src/Pagerfanta/Adapter/PropelAdapter.php
+++ b/src/Pagerfanta/Adapter/PropelAdapter.php
@@ -41,7 +41,8 @@ class PropelAdapter implements AdapterInterface
      */
     public function getNbResults()
     {
-        return $this->query->limit(0)->count();
+        $q = clone $this->getQuery();
+        return $q->limit(0)->offset(0)->count();
     }
 
     /**
@@ -49,6 +50,7 @@ class PropelAdapter implements AdapterInterface
      */
     public function getSlice($offset, $length)
     {
-        return $this->query->limit($length)->offset($offset)->find();
+        $q = clone $this->getQuery();
+        return $q->limit($length)->offset($offset)->find();
     }
 }


### PR DESCRIPTION
```
 $query = \Admingenerator\PropelDemoBundle\Model\MovieQuery::create('q')
 $paginator = new Pagerfanta(new PagerAdapter($query));
 $paginator->setMaxPerPage(3);
 $paginator->setCurrentPage($this->getPage(), false, true);
```

```
SELECT propel_movies.ID, propel_movies.TITLE, propel_movies.IS_PUBLISHED, propel_movies.RELEASE_DATE, propel_movies.PRODUCER_ID
FROM `propel_movies` LIMIT 3
Time: 0.041 sec - Memory: 22.1 MB
SELECT COUNT(*)
FROM (SELECT propel_movies.ID, propel_movies.TITLE, propel_movies.IS_PUBLISHED, propel_movies.RELEASE_DATE, propel_movies.PRODUCER_ID
FROM `propel_movies` LIMIT 3) propelmatch4cnt
Time: 0.002 sec - Memory: 24.6 MB
```

So was always make one page !!
