### PR TITLE
Patch for issue #23 Hints are not copied when the original query is cloned in DoctrineORMAdapter

### DIFF
--- a/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
+++ b/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
@@ -138,10 +138,10 @@ class DoctrineORMAdapter implements AdapterInterface
         /* @var $cloneQuery Query */
         $cloneQuery = clone $query;
         $cloneQuery->setParameters($query->getParameters());
-        foreach($query->getHints() as $name => $value)
-        {
+        foreach($query->getHints() as $name => $value) {
             $cloneQuery->setHint($name, $value);
         }
+
         return $cloneQuery;
     }
 }


### PR DESCRIPTION
issue #23 Hints are not copied when the original query is cloned in DoctrineORMAdapter
