### PR TITLE
Let Pagerfanta Implement \Countable interface

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -248,7 +248,8 @@ class Pagerfanta implements PagerfantaInterface, \IteratorAggregate, \Countable
      * Even thought we work with only a slice of data, from user's perspective,
      * the count of rows in a database refers to the total number of results.
      */
-    public function count() {
+    public function count() 
+    {
         return $this->getNbResults();
     }
     


### PR DESCRIPTION
Hi,

Thanks for the great paginator, that I've been using for some time now.
Still, there is this small usability issue, I'd like to address.

USE CASE:
In back-end modules I work with, I usually use Pagerfanta instances directly in Twig templates.
Some of them being generic and having either Pagerfanta instances, or other Traversable objects or arrays.
So I wanted to propose the usage of \Countable, so there would be no necessity to use Pagerfanta's own getNbResults() call to check the number of records found in the database or if there are any results at all.
