### PR TITLE
Change default value of $fetchJoinCollection to true in Pagerfanta\Adapter\DoctrineORMAdapter

### DIFF
--- a/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
+++ b/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
@@ -36,11 +36,11 @@ class DoctrineORMAdapter implements AdapterInterface
      * Constructor.
      *
      * @param Query|QueryBuilder $query               A Doctrine ORM query or query builder.
-     * @param Boolean            $fetchJoinCollection Whether the query joins a collection (false by default).
+     * @param Boolean            $fetchJoinCollection Whether the query joins a collection (true by default).
      *
      * @api
      */
-    public function __construct($query, $fetchJoinCollection = false)
+    public function __construct($query, $fetchJoinCollection = true)
     {
         if ($query instanceof QueryBuilder) {
             $query = $query->getQuery();


### PR DESCRIPTION
I guess it would be a BC break, but I think that changing the default option for `$fetchJoinCollection` to true in the DoctrineORMAdapter makes sense. With this change all pagination operations on ORM based queries will succeed by default. If someone worries about the performance a pagination query, then it's still possible to adjust that query to _not_ create a `WHERE .. IN` query.

Also note that the DoctrineExtensions by @beberlei only gives the user the option to paginate with the extra `WHERE .. IN` query, probably for the reasons noted above (sane defaults for most users).
