### PR TITLE
Refactored the ORM pagination to use the native one in 2.2

### DIFF
--- a/src/Pagerfanta/Adapter/DoctrineORM/Paginator.php
+++ b/src/Pagerfanta/Adapter/DoctrineORM/Paginator.php
@@ -18,6 +18,9 @@ use Doctrine\ORM\NoResultException;
 /**
  * DoctrineORM Paginator.
  *
+ * This class emulates Doctrine\ORM\Tools\Pagination\Paginator for older
+ * Doctrine versions.
+ *
  * @author Pablo Díez <pablodip@gmail.com>
  * @author Benjamin Eberlei <kontakt@beberlei.de>
  *

--- a/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
+++ b/src/Pagerfanta/Adapter/DoctrineORMAdapter.php
@@ -17,15 +17,14 @@ use Pagerfanta\Adapter\DoctrineORM\Paginator as LegacyPaginator;
 /**
  * DoctrineORMAdapter.
  *
- * @author Pablo Díez <pablodip@gmail.com>
- * @author Benjamin Eberlei <kontakt@beberlei.de>
+ * @author Christophe Coevoet <stof@notk.org>
  *
  * @api
  */
 class DoctrineORMAdapter implements AdapterInterface
 {
     /**
-     * @var Query
+     * @var \Doctrine\ORM\Tools\Pagination\Paginator|\Pagerfanta\Adapter\DoctrineORM\Paginator
      */
     private $paginator;
 


### PR DESCRIPTION
I moved the existing pagination logic in a Paginator class which implements `Countable` and `IteratorAgregate` in the same way the native ORM class does in 2.2
The adapter will use the ORM class when available, and will fallback to the Pagerfanta one when uisng an older version of Doctrine.

All tests are passing: ![Build Status](https://secure.travis-ci.org/stof/Pagerfanta-1.png?branch=doctrine_orm_native)
