### PR TITLE
setCurrentPage throw LessThan1CurrentPageException

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -127,7 +127,7 @@ class Pagerfanta implements PagerfantaInterface
 
         // less than 1?
         if ($currentPage < 1) {
-            $currentPage = 1;
+            throw new LessThan1CurrentPageException();
         }
 
         $this->currentPageResults = null;


### PR DESCRIPTION
setCurrentPage is supposed to throw a LessThan1CurrentPageException when the given currentPage is < 1, which wasn't the case, as it replaced any < 1 value by "1".
