### PR TITLE
Added the branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
     },
     "autoload": {
         "psr-0": { "Pagerfanta\\": "src/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
This allows other packages to define a range requirement (`1.0.*` for instance) and still being able to have the dev version matching the requirement.

See http://getcomposer.org/doc/articles/aliases.md for the doc about composer aliases
