### PR TITLE
Added unit test for Doctrine Query Builder

### DIFF
--- a/tests/Pagerfanta/Tests/Adapter/DoctrineORMAdapterTest.php
+++ b/tests/Pagerfanta/Tests/Adapter/DoctrineORMAdapterTest.php
@@ -168,4 +168,22 @@ DQL;
         $this->assertEquals('Foo', $items[0][0]->name);
         $this->assertEquals(1, $items[0]['relevance']);
     }
+
+    public function testQueryBuilder()
+    {
+        $queryBuilder = $this->entityManager->createQueryBuilder()
+            ->select('u')
+            ->from('Pagerfanta\Tests\Adapter\DoctrineORM\User', 'u');
+
+        $adapter = new DoctrineORMAdapter($queryBuilder);
+        $this->assertEquals(2, $adapter->getNbResults());
+
+        $items = $adapter->getSlice(0, 10);
+        $this->assertCount(2, $items);
+
+        foreach ($items as $item) {
+            $this->assertObjectHasAttribute('id', $item);
+            $this->assertObjectHasAttribute('groups', $item);
+        }
+    }
 }


### PR DESCRIPTION
I had an issue, and wasn't sure whether it was a problem of the `DoctrineORMAdapter` with `QueryBuilder` so I added a unit test (since there was none before). Turns out, everything is fine, but there is no harm in adding the test.
