### PR TITLE
Remove unused property, fixes #79

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -151,7 +151,6 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
     {
         $this->currentPageResults = null;
         $this->nbResults = null;
-        $this->nbPages = null;
     }
 
     /**


### PR DESCRIPTION
So what happened is that you removed the `private $nbPages;`, which means the property wasn't declared anymore. Setting it to null declares a new public property (yay dynamic languages:p), and then twig sees that and reads it out instead of looking for a getter as it did before when it was private.
