### PR TITLE
Add options in default template to override string generated

### DIFF
--- a/src/Pagerfanta/View/Template/DefaultTemplate.php
+++ b/src/Pagerfanta/View/Template/DefaultTemplate.php
@@ -17,17 +17,20 @@ namespace Pagerfanta\View\Template;
 class DefaultTemplate extends Template
 {
     static protected $defaultOptions = array(
-        'previous_message'   => 'Previous',
-        'next_message'       => 'Next',
-        'css_disabled_class' => 'disabled',
-        'css_dots_class'     => 'dots',
-        'css_current_class'  => 'current',
-        'dots_text'          => '...'
+        'previous_message'        => 'Previous',
+        'next_message'            => 'Next',
+        'css_disabled_class'      => 'disabled',
+        'css_dots_class'          => 'dots',
+        'css_current_class'       => 'current',
+        'dots_text'               => '...',
+        'container_template'      => '<nav>%pages%</nav>',
+        'page_with_text_template' => '<a href="%s">%s</a>',
+        'span_template'           => '<span class="%s">%s</span>'
     );
 
     public function container()
     {
-        return '<nav>%pages%</nav>';
+        return $this->option('container_template');
     }
 
     public function page($page)
@@ -39,7 +42,7 @@ class DefaultTemplate extends Template
 
     public function pageWithText($page, $text)
     {
-        return sprintf('<a href="%s">%s</a>', $this->generateRoute($page), $text);
+        return sprintf($this->option('page_with_text_template'), $this->generateRoute($page), $text);
     }
 
     public function previousDisabled()
@@ -84,6 +87,6 @@ class DefaultTemplate extends Template
 
     private function generateSpan($class, $page)
     {
-        return sprintf('<span class="%s">%s</span>', $class, $page);
+        return sprintf($this->option('span_template'), $class, $page);
     }
 }

--- a/tests/Pagerfanta/Tests/View/DefaultViewTest.php
+++ b/tests/Pagerfanta/Tests/View/DefaultViewTest.php
@@ -261,6 +261,35 @@ EOF
 EOF
         , $this->renderView($options));
     }
+    
+    public function testRenderModifiyingStringTemplate()
+    {
+        $this->setNbPages(100);
+        $this->setCurrentPage(1);
+        
+        $options = array(
+            'container_template'      => '<nav><ul>%pages%</ul></nav>',
+            'page_with_text_template' => '<li><a href="%s">%s</a></li>',
+            'span_template'           => '<li><span class="%s">%s</span></li>'
+        );
+        
+        $this->assertRenderedView(<<<EOF
+<nav>
+    <ul>
+        <li><span class="disabled">Previous</span></li>
+        <li><span class="current">1</span></li>
+        <li><a href="|2|">2</a></li>
+        <li><a href="|3|">3</a></li>
+        <li><a href="|4|">4</a></li>
+        <li><a href="|5|">5</a></li>
+        <li><span class="dots">...</span></li>
+        <li><a href="|100|">100</a></li>
+        <li><a href="|2|">Next</a></li>
+    </ul>
+</nav>
+EOF
+        , $this->renderView($options));
+    }
 
     protected function filterExpectedView($expected)
     {


### PR DESCRIPTION
Add 3 new options : 
- container_template : To override global layout of pagination
- page_with_text_template : To override link in pagination
- span_template : To override simple text in pagination

I keep the container method for BC but maybe it will be better to remove it in a futur version ?
