### PR TITLE
Protection from negative result offset

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -306,7 +306,7 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
 
     private function calculateOffsetForCurrentPageResults()
     {
-        return ($this->getCurrentPage() - 1) * $this->getMaxPerPage();
+        return abs(($this->getCurrentPage() - 1) * $this->getMaxPerPage());
     }
 
     /**


### PR DESCRIPTION
Issue when getCurrentPage returns 0, offset becomes -10
