### PR TITLE
[RFC] Add current page start and end count

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -459,4 +459,24 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
     {
         return (is_string($value) || is_float($value)) && (int) $value == $value;
     }
+
+    /**
+     * Calculate the current page offset start
+     *
+     * @return int
+     */
+    public function getCurrentPageOffsetStart()
+    {
+        return $this->getNbResults() ? $this->calculateOffsetForCurrentPageResults() + 1 : 0;
+    }
+
+    /**
+     * Calculate the current page offset end
+     *
+     * @return int
+     */
+    public function getCurrentPageOffsetEnd()
+    {
+        return $this->hasNextPage() ? $this->getCurrentPage() * $this->getMaxPerPage() : $this->getNbResults();
+    }
 }

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -654,4 +654,33 @@ class PagerfantaTest extends \PHPUnit_Framework_TestCase
         $callback();
         $this->assertSame($currentPageResults1, $this->pagerfanta->getCurrentPageResults());
     }
+
+
+    public function testGetCurrentPageOffsetStart()
+    {
+        $this->setAdapterNbResultsAny(100);
+        $this->pagerfanta->setMaxPerPage(10);
+        $this->pagerfanta->setCurrentPage(2);
+
+        $this->assertSame(11, $this->pagerfanta->getCurrentPageOffsetStart());
+    }
+
+    public function testGetCurrentPageOffsetEnd()
+    {
+        $this->setAdapterNbResultsAny(100);
+        $this->pagerfanta->setMaxPerPage(10);
+        $this->pagerfanta->setCurrentPage(2);
+
+        $this->assertSame(20, $this->pagerfanta->getCurrentPageOffsetEnd());
+    }
+
+    public function testGetCurrentPageOffsetEndOnEndPage()
+    {
+        $this->setAdapterNbResultsAny(90);
+        $this->pagerfanta->setMaxPerPage(20);
+        $this->pagerfanta->setCurrentPage(5);
+
+        $this->assertSame(90, $this->pagerfanta->getCurrentPageOffsetEnd());
+    }
+
 }


### PR DESCRIPTION
This PR adds the ability to calculate the current page start and end count.

Example (in twig):

`<p>Showing {{ pagination.getCurrentPageOffsetStart }} - {{ pagination.getCurrentPageOffsetEnd }} of {{ pagination.getNbResults }} results</p>`
