### PR TITLE
[RFC] Added data-pagination to view output. 

### DIFF
--- a/src/Pagerfanta/View/DefaultView.php
+++ b/src/Pagerfanta/View/DefaultView.php
@@ -83,13 +83,25 @@ class DefaultView implements ViewInterface
     private function generate()
     {
         $pages = $this->generatePages();
+        $paginationData = $this->getPaginationData();
 
-        return $this->generateContainer($pages);
+        return $this->generateContainer($pages, $paginationData);
     }
 
-    private function generateContainer($pages)
+    private function generateContainer($pages, $paginationData)
     {
-        return str_replace('%pages%', $pages, $this->template->container());
+        return str_replace(array('%pages%', '%paginationData%'), array($pages, json_encode($paginationData)), $this->template->container());
+    }
+
+    private function getPaginationData(){
+        return array(
+            "url" => $this->template->generateRoute(null),
+            "totalResults" => $this->pagerfanta->getNbResults(),
+            "totalPages" => $this->pagerfanta->getNbPages(),
+            "currentPage" => $this->pagerfanta->getCurrentPage(),
+            "currentPageOffsetStart" => $this->pagerfanta->getCurrentPageOffsetStart(),
+            "currentPageOffsetEnd" => $this->pagerfanta->getCurrentPageOffsetEnd()
+        );
     }
 
     private function generatePages()

--- a/src/Pagerfanta/View/Template/DefaultTemplate.php
+++ b/src/Pagerfanta/View/Template/DefaultTemplate.php
@@ -23,14 +23,15 @@ class DefaultTemplate extends Template
         'css_dots_class'     => 'dots',
         'css_current_class'  => 'current',
         'dots_text'          => '...',
-        'container_template' => '<nav>%pages%</nav>',
         'page_template'      => '<a href="%href%">%text%</a>',
         'span_template'      => '<span class="%class%">%text%</span>'
     );
 
     public function container()
     {
-        return $this->option('container_template');
+        return sprintf('<nav class="%s" data-pagination=\'%%paginationData%%\'>%%pages%%</nav>',
+            $this->option('css_container_class')
+        );
     }
 
     public function page($page)

--- a/src/Pagerfanta/View/Template/Template.php
+++ b/src/Pagerfanta/View/Template/Template.php
@@ -41,7 +41,7 @@ abstract class Template implements TemplateInterface
         $this->options = static::$defaultOptions;
     }
 
-    protected function generateRoute($page)
+    public function generateRoute($page)
     {
         return call_user_func($this->getRouteGenerator(), $page);
     }

--- a/src/Pagerfanta/View/Template/TwitterBootstrapTemplate.php
+++ b/src/Pagerfanta/View/Template/TwitterBootstrapTemplate.php
@@ -33,7 +33,7 @@ class TwitterBootstrapTemplate extends Template
 
     public function container()
     {
-        return sprintf('<div class="%s"><ul>%%pages%%</ul></div>',
+        return sprintf('<div class="%s" data-pagination=\'%%paginationData%%\'><ul>%%pages%%</ul></div>',
             $this->option('css_container_class')
         );
     }


### PR DESCRIPTION
The data attribute is a json_encoded array of the following:

* url
* totalResults
* totalPages
* currentPage
* currentPageOffsetStart
* currentPageOffsetEnd

Builds on top off PR #91

Is this something that interests anyone?

This update makes it easier to add other JS hooks / events. I'm currently using it to build a perPage select box:

![image](https://f.cloud.github.com/assets/25124/510474/8096a0a8-bdd5-11e2-8388-3e75088b9d50.png)

The method in my widget looks like:

````js
        _processPerPage: function (event) {

            event.preventDefault();

            var paginationData = this.element.find(this.options.paginationSelector).data('pagination'),
                currentOffset = paginationData.currentPageOffsetStart,
                perPage = $(event.target).val(),
                newPage = Math.ceil(currentOffset / perPage),
                uri = new URI(paginationData.url);

            uri.setSearch(this.options.pageKey, newPage);
            uri.setSearch(this.options.perPageKey, perPage);

            $.ajax({
                type: 'get',
                url: uri.href(),
                beforeSend: $.proxy(this._beforeSend, this),
                success: $.proxy(this._success, this),
                complete: $.proxy(this._complete, this)
            });

        },
````