### PR TITLE
DefaultView::last should call the method last from the Template

### DIFF
--- a/src/Pagerfanta/View/DefaultView.php
+++ b/src/Pagerfanta/View/DefaultView.php
@@ -217,7 +217,7 @@ class DefaultView implements ViewInterface
     private function last()
     {
         if ($this->pagerfanta->getNbPages() > $this->endPage) {
-            return $this->template->page($this->pagerfanta->getNbPages());
+            return $this->template->last($this->pagerfanta->getNbPages());
         }
     }
 


### PR DESCRIPTION
Actually, the method ViewInterface::last() is never called because the view
is using the method ViewInterface::page().

This commit fix this bug.
