### PR TITLE
SolariumAdapter may now only do 1 query in some circumstances

### DIFF
--- a/src/Pagerfanta/Adapter/SolariumAdapter.php
+++ b/src/Pagerfanta/Adapter/SolariumAdapter.php
@@ -28,6 +28,8 @@ class SolariumAdapter implements AdapterInterface
     private $query;
     private $resultSet;
     private $endPoint;
+    private $resultSetStart;
+    private $resultSetRows;
 
     /**
      * Constructor.
@@ -97,40 +99,41 @@ class SolariumAdapter implements AdapterInterface
      */
     public function getSlice($offset, $length)
     {
-        $this->query
-            ->setStart($offset)
-            ->setRows($length);
-
-        $this->clearResultSet();
-
-        return $this->getResultSet();
+        return $this->getResultSet($offset, $length);
     }
 
     /**
      * @return Solarium_Result_Select|Solarium\QueryType\Select\Result\Result
      **/
-    public function getResultSet()
+    public function getResultSet($start = null, $rows = null)
     {
-        if ($this->isResultSetNotCached()) {
+        if ($this->resultSet === null || $this->resultSetStartOrRowsChange($start, $rows)) {
+            if (null !== $start || null !== $rows) {
+                $this->query
+                    ->setStart($start)
+                    ->setRows($rows)
+                ;
+            }
+
             $this->resultSet = $this->createResultSet();
+            $this->resultSetStart = $start;
+            $this->resultSetRows = $rows;
         }
 
         return $this->resultSet;
     }
 
-    private function isResultSetNotCached()
+    private function resultSetStartOrRowsChange($start, $rows)
     {
-        return $this->resultSet === null;
+        return
+            null !== $start && null !== $rows
+            && ($start !== $this->resultSetStart || $rows !== $this->resultSetRows)
+        ;
     }
 
     private function createResultSet()
     {
         return $this->client->select($this->query, $this->endPoint);
-    }
-
-    private function clearResultSet()
-    {
-        $this->resultSet = null;
     }
 
     public function setEndPoint($endPoint)

--- a/tests/Pagerfanta/Tests/Adapter/SolariumAdapterTest.php
+++ b/tests/Pagerfanta/Tests/Adapter/SolariumAdapterTest.php
@@ -124,6 +124,54 @@ abstract class SolariumAdapterTest extends \PHPUnit_Framework_TestCase
         $adapter->getSlice(1, 200);
     }
 
+    public function testGetNbResultCanUseAGetSliceCachedResultSet()
+    {
+        $query = $this->createQueryStub();
+
+        $client = $this->createClientMock();
+        $client
+            ->expects($this->exactly(1))
+            ->method('select')
+            ->will($this->returnValue($this->createResultMock()));
+
+        $adapter = new SolariumAdapter($client, $query);
+
+        $adapter->getSlice(1, 200);
+        $adapter->getNbResults();
+    }
+
+    public function testSameGetSliceUseACachedResultSet()
+    {
+        $query = $this->createQueryStub();
+
+        $client = $this->createClientMock();
+        $client
+            ->expects($this->exactly(1))
+            ->method('select')
+            ->will($this->returnValue($this->createResultMock()));
+
+        $adapter = new SolariumAdapter($client, $query);
+
+        $adapter->getSlice(1, 200);
+        $adapter->getSlice(1, 200);
+    }
+
+    public function testDifferentGetSliceCannotUseACachedResultSet()
+    {
+        $query = $this->createQueryStub();
+
+        $client = $this->createClientMock();
+        $client
+            ->expects($this->exactly(2))
+            ->method('select')
+            ->will($this->returnValue($this->createResultMock()));
+
+        $adapter = new SolariumAdapter($client, $query);
+
+        $adapter->getSlice(1, 200);
+        $adapter->getSlice(2, 200);
+    }
+
     public function testGetResultSet()
     {
         $query = $this->createQueryMock();


### PR DESCRIPTION
So now, if `getSlice()` is called before `getNbResults()`, only 1 query will be done.
