### PR TITLE
use HYDRATE_PHPCR query mode for ODM Adapter count

### DIFF
--- a/src/Pagerfanta/Adapter/DoctrineODMPhpcrAdapter.php
+++ b/src/Pagerfanta/Adapter/DoctrineODMPhpcrAdapter.php
@@ -47,7 +47,7 @@ class DoctrineODMPhpcrAdapter implements AdapterInterface
      */
     public function getNbResults()
     {
-        return count($this->queryBuilder->getQuery()->execute());
+        return $this->queryBuilder->getQuery()->execute(null, Query::HYDRATE_PHPCR)->getRows()->count();
     }
 
     /**


### PR DESCRIPTION
for large collections  this has a smaller memory footprint and seems to be faster
