### PR TITLE
Add attribute rel="prev/next" for SEO

### DIFF
--- a/src/Pagerfanta/View/Template/DefaultTemplate.php
+++ b/src/Pagerfanta/View/Template/DefaultTemplate.php
@@ -24,8 +24,10 @@ class DefaultTemplate extends Template
         'css_current_class'  => 'current',
         'dots_text'          => '...',
         'container_template' => '<nav>%pages%</nav>',
-        'page_template'      => '<a href="%href%">%text%</a>',
-        'span_template'      => '<span class="%class%">%text%</span>'
+        'page_template'      => '<a href="%href%"%rel>%text%</a>',
+        'span_template'      => '<span class="%class%">%text%</span>',
+        'rel_previous'        => 'prev',
+        'rel_next'            => 'next'
     );
 
     public function container()
@@ -40,12 +42,12 @@ class DefaultTemplate extends Template
         return $this->pageWithText($page, $text);
     }
 
-    public function pageWithText($page, $text)
+    public function pageWithText($page, $text, $rel = null)
     {
-        $search = array('%href%', '%text%');
+        $search = array('%href%', '%text%', '%rel');
 
         $href = $this->generateRoute($page);
-        $replace = array($href, $text);
+        $replace = $rel ? array($href, $text, ' rel="' . $rel . '"') : array($href, $text, '');
 
         return str_replace($search, $replace, $this->option('page_template'));
     }
@@ -57,7 +59,7 @@ class DefaultTemplate extends Template
 
     public function previousEnabled($page)
     {
-        return $this->pageWithText($page, $this->option('previous_message'));
+        return $this->pageWithText($page, $this->option('previous_message'), $this->option('rel_previous'));
     }
 
     public function nextDisabled()
@@ -67,7 +69,7 @@ class DefaultTemplate extends Template
 
     public function nextEnabled($page)
     {
-        return $this->pageWithText($page, $this->option('next_message'));
+        return $this->pageWithText($page, $this->option('next_message'), $this->option('rel_next'));
     }
 
     public function first()

--- a/src/Pagerfanta/View/Template/TwitterBootstrapTemplate.php
+++ b/src/Pagerfanta/View/Template/TwitterBootstrapTemplate.php
@@ -28,7 +28,9 @@ class TwitterBootstrapTemplate extends Template
         'css_next_class'      => 'next',
         'css_disabled_class'  => 'disabled',
         'css_dots_class'      => 'disabled',
-        'css_active_class'    => 'active'
+        'css_active_class'    => 'active',
+        'rel_previous'        => 'prev',
+        'rel_next'            => 'next'
     );
 
     public function container()
@@ -52,11 +54,11 @@ class TwitterBootstrapTemplate extends Template
         return $this->pageWithTextAndClass($page, $text, $class);
     }
 
-    private function pageWithTextAndClass($page, $text, $class)
+    private function pageWithTextAndClass($page, $text, $class, $rel = null)
     {
         $href = $this->generateRoute($page);
 
-        return $this->li($class, $href, $text);
+        return $this->li($class, $href, $text, $rel);
     }
 
     public function previousDisabled()
@@ -77,8 +79,9 @@ class TwitterBootstrapTemplate extends Template
     {
         $text = $this->option('prev_message');
         $class = $this->option('css_prev_class');
+        $rel = $this->option('rel_previous');
 
-        return $this->pageWithTextAndClass($page, $text, $class);
+        return $this->pageWithTextAndClass($page, $text, $class, $rel);
     }
 
     public function nextDisabled()
@@ -99,8 +102,9 @@ class TwitterBootstrapTemplate extends Template
     {
         $text = $this->option('next_message');
         $class = $this->option('css_next_class');
+        $rel = $this->option('rel_next');
 
-        return $this->pageWithTextAndClass($page, $text, $class);
+        return $this->pageWithTextAndClass($page, $text, $class, $rel);
     }
 
     public function first()
@@ -130,10 +134,11 @@ class TwitterBootstrapTemplate extends Template
         return $this->li($class, $href, $text);
     }
 
-    private function li($class, $href, $text)
+    private function li($class, $href, $text, $rel = null)
     {
         $liClass = $class ? sprintf(' class="%s"', $class) : '';
+        $rel = $rel ? sprintf(' rel="%s"', $rel) : '';
 
-        return sprintf('<li%s><a href="%s">%s</a></li>', $liClass, $href, $text);
+        return sprintf('<li%s><a href="%s"%s>%s</a></li>', $liClass, $href, $rel, $text);
     }
 }

--- a/tests/Pagerfanta/Tests/View/DefaultViewTest.php
+++ b/tests/Pagerfanta/Tests/View/DefaultViewTest.php
@@ -20,7 +20,7 @@ class DefaultViewTest extends ViewTestCase
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|9|">Previous</a>
+    <a href="|9|" rel="prev">Previous</a>
     <a href="|1|">1</a>
     <span class="dots">...</span>
     <a href="|8|">8</a>
@@ -30,10 +30,10 @@ class DefaultViewTest extends ViewTestCase
     <a href="|12|">12</a>
     <span class="dots">...</span>
     <a href="|100|">100</a>
-    <a href="|11|">Next</a>
+    <a href="|11|" rel="next">Next</a>
 </nav>
 EOF
-        , $this->renderView($options));
+            , $this->renderView($options));
     }
 
     public function testRenderFirstPage()
@@ -53,7 +53,7 @@ EOF
     <a href="|5|">5</a>
     <span class="dots">...</span>
     <a href="|100|">100</a>
-    <a href="|2|">Next</a>
+    <a href="|2|" rel="next">Next</a>
 </nav>
 EOF
         , $this->renderView($options));
@@ -68,7 +68,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|99|">Previous</a>
+    <a href="|99|" rel="prev">Previous</a>
     <a href="|1|">1</a>
     <span class="dots">...</span>
     <a href="|96|">96</a>
@@ -91,7 +91,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|3|">Previous</a>
+    <a href="|3|" rel="prev">Previous</a>
     <a href="|1|">1</a>
     <a href="|2|">2</a>
     <a href="|3|">3</a>
@@ -100,7 +100,7 @@ EOF
     <a href="|6|">6</a>
     <span class="dots">...</span>
     <a href="|100|">100</a>
-    <a href="|5|">Next</a>
+    <a href="|5|" rel="next">Next</a>
 </nav>
 EOF
         , $this->renderView($options));
@@ -115,7 +115,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|4|">Previous</a>
+    <a href="|4|" rel="prev">Previous</a>
     <a href="|1|">1</a>
     <a href="|2|">2</a>
     <a href="|3|">3</a>
@@ -125,7 +125,7 @@ EOF
     <a href="|7|">7</a>
     <span class="dots">...</span>
     <a href="|100|">100</a>
-    <a href="|6|">Next</a>
+    <a href="|6|" rel="next">Next</a>
 </nav>
 EOF
         , $this->renderView($options));
@@ -140,7 +140,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|96|">Previous</a>
+    <a href="|96|" rel="prev">Previous</a>
     <a href="|1|">1</a>
     <span class="dots">...</span>
     <a href="|95|">95</a>
@@ -149,7 +149,7 @@ EOF
     <a href="|98|">98</a>
     <a href="|99|">99</a>
     <a href="|100|">100</a>
-    <a href="|98|">Next</a>
+    <a href="|98|" rel="next">Next</a>
 </nav>
 EOF
         , $this->renderView($options));
@@ -164,7 +164,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|95|">Previous</a>
+    <a href="|95|" rel="prev">Previous</a>
     <a href="|1|">1</a>
     <span class="dots">...</span>
     <a href="|94|">94</a>
@@ -174,7 +174,7 @@ EOF
     <a href="|98|">98</a>
     <a href="|99|">99</a>
     <a href="|100|">100</a>
-    <a href="|97|">Next</a>
+    <a href="|97|" rel="next">Next</a>
 </nav>
 EOF
         , $this->renderView($options));
@@ -189,7 +189,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|9|">Previous</a>
+    <a href="|9|" rel="prev">Previous</a>
     <a href="|1|">1</a>
     <span class="dots">...</span>
     <a href="|7|">7</a>
@@ -201,7 +201,7 @@ EOF
     <a href="|13|">13</a>
     <span class="dots">...</span>
     <a href="|100|">100</a>
-    <a href="|11|">Next</a>
+    <a href="|11|" rel="next">Next</a>
 </nav>
 EOF
         , $this->renderView($options));
@@ -219,7 +219,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <nav>
-    <a href="|9|">Anterior</a>
+    <a href="|9|" rel="prev">Anterior</a>
     <a href="|1|">1</a>
     <span class="dots">...</span>
     <a href="|8|">8</a>
@@ -229,7 +229,7 @@ EOF
     <a href="|12|">12</a>
     <span class="dots">...</span>
     <a href="|100|">100</a>
-    <a href="|11|">Siguiente</a>
+    <a href="|11|" rel="next">Siguiente</a>
 </nav>
 EOF
         , $this->renderView($options));
@@ -256,7 +256,7 @@ EOF
     <a href="|5|">5</a>
     <span class="puntos">...</span>
     <a href="|100|">100</a>
-    <a href="|2|">Next</a>
+    <a href="|2|" rel="next">Next</a>
 </nav>
 EOF
         , $this->renderView($options));

--- a/tests/Pagerfanta/Tests/View/DefaultViewWithCustomTemplateTest.php
+++ b/tests/Pagerfanta/Tests/View/DefaultViewWithCustomTemplateTest.php
@@ -24,7 +24,7 @@ class DefaultViewTestWithCustomTemplateTest extends ViewTestCase
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|9|">&larr; Previous</a></li>
+        <li class="prev"><a href="|9|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|8|">8</a></li>
@@ -34,7 +34,7 @@ class DefaultViewTestWithCustomTemplateTest extends ViewTestCase
         <li><a href="|12|">12</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|11|">Next &rarr;</a></li>
+        <li class="next"><a href="|11|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF

--- a/tests/Pagerfanta/Tests/View/TwitterBootstrap3ViewTest.php
+++ b/tests/Pagerfanta/Tests/View/TwitterBootstrap3ViewTest.php
@@ -22,7 +22,7 @@ class TwitterBootstrap3ViewTest extends TwitterBootstrapViewTest
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|9|">&larr; Previous</a></li>
+    <li class="prev"><a href="|9|" rel="prev">&larr; Previous</a></li>
     <li><a href="|1|">1</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|7|">7</a></li>
@@ -34,7 +34,7 @@ class TwitterBootstrap3ViewTest extends TwitterBootstrapViewTest
     <li><a href="|13|">13</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|11|">Next &rarr;</a></li>
+    <li class="next"><a href="|11|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -59,7 +59,7 @@ EOF
     <li><a href="|7|">7</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|2|">Next &rarr;</a></li>
+    <li class="next"><a href="|2|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -74,7 +74,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|99|">&larr; Previous</a></li>
+    <li class="prev"><a href="|99|" rel="prev">&larr; Previous</a></li>
     <li><a href="|1|">1</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|94|">94</a></li>
@@ -99,7 +99,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|3|">&larr; Previous</a></li>
+    <li class="prev"><a href="|3|" rel="prev">&larr; Previous</a></li>
     <li><a href="|1|">1</a></li>
     <li><a href="|2|">2</a></li>
     <li><a href="|3|">3</a></li>
@@ -109,7 +109,7 @@ EOF
     <li><a href="|7|">7</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|5|">Next &rarr;</a></li>
+    <li class="next"><a href="|5|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -124,7 +124,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|4|">&larr; Previous</a></li>
+    <li class="prev"><a href="|4|" rel="prev">&larr; Previous</a></li>
     <li><a href="|1|">1</a></li>
     <li><a href="|2|">2</a></li>
     <li><a href="|3|">3</a></li>
@@ -135,7 +135,7 @@ EOF
     <li><a href="|8|">8</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|6|">Next &rarr;</a></li>
+    <li class="next"><a href="|6|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -150,7 +150,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|96|">&larr; Previous</a></li>
+    <li class="prev"><a href="|96|" rel="prev">&larr; Previous</a></li>
     <li><a href="|1|">1</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|94|">94</a></li>
@@ -160,7 +160,7 @@ EOF
     <li><a href="|98|">98</a></li>
     <li><a href="|99|">99</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|98|">Next &rarr;</a></li>
+    <li class="next"><a href="|98|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -175,7 +175,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|95|">&larr; Previous</a></li>
+    <li class="prev"><a href="|95|" rel="prev">&larr; Previous</a></li>
     <li><a href="|1|">1</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|93|">93</a></li>
@@ -186,7 +186,7 @@ EOF
     <li><a href="|98|">98</a></li>
     <li><a href="|99|">99</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|97|">Next &rarr;</a></li>
+    <li class="next"><a href="|97|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -201,7 +201,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|9|">&larr; Previous</a></li>
+    <li class="prev"><a href="|9|" rel="prev">&larr; Previous</a></li>
     <li><a href="|1|">1</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|8|">8</a></li>
@@ -211,7 +211,7 @@ EOF
     <li><a href="|12|">12</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|11|">Next &rarr;</a></li>
+    <li class="next"><a href="|11|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -229,7 +229,7 @@ EOF
 
         $this->assertRenderedView(<<<EOF
 <ul class="pagination">
-    <li class="prev"><a href="|9|">Anterior</a></li>
+    <li class="prev"><a href="|9|" rel="prev">Anterior</a></li>
     <li><a href="|1|">1</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|7|">7</a></li>
@@ -241,7 +241,7 @@ EOF
     <li><a href="|13|">13</a></li>
     <li class="disabled"><a href="#">&hellip;</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="next"><a href="|11|">Siguiente</a></li>
+    <li class="next"><a href="|11|" rel="next">Siguiente</a></li>
 </ul>
 EOF
             , $this->renderView($options));
@@ -273,7 +273,7 @@ EOF
     <li><a href="|7|">7</a></li>
     <li class="puntos"><a href="#">&hellip;</a></li>
     <li><a href="|100|">100</a></li>
-    <li class="siguiente"><a href="|2|">Next &rarr;</a></li>
+    <li class="siguiente"><a href="|2|" rel="next">Next &rarr;</a></li>
 </ul>
 EOF
             , $this->renderView($options));

--- a/tests/Pagerfanta/Tests/View/TwitterBootstrapViewTest.php
+++ b/tests/Pagerfanta/Tests/View/TwitterBootstrapViewTest.php
@@ -21,7 +21,7 @@ class TwitterBootstrapViewTest extends ViewTestCase
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|9|">&larr; Previous</a></li>
+        <li class="prev"><a href="|9|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|7|">7</a></li>
@@ -33,7 +33,7 @@ class TwitterBootstrapViewTest extends ViewTestCase
         <li><a href="|13|">13</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|11|">Next &rarr;</a></li>
+        <li class="next"><a href="|11|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF
@@ -60,7 +60,7 @@ EOF
         <li><a href="|7|">7</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|2|">Next &rarr;</a></li>
+        <li class="next"><a href="|2|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF
@@ -77,7 +77,7 @@ EOF
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|99|">&larr; Previous</a></li>
+        <li class="prev"><a href="|99|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|94|">94</a></li>
@@ -104,7 +104,7 @@ EOF
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|3|">&larr; Previous</a></li>
+        <li class="prev"><a href="|3|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li><a href="|2|">2</a></li>
         <li><a href="|3|">3</a></li>
@@ -114,7 +114,7 @@ EOF
         <li><a href="|7|">7</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|5|">Next &rarr;</a></li>
+        <li class="next"><a href="|5|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF
@@ -131,7 +131,7 @@ EOF
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|4|">&larr; Previous</a></li>
+        <li class="prev"><a href="|4|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li><a href="|2|">2</a></li>
         <li><a href="|3|">3</a></li>
@@ -142,7 +142,7 @@ EOF
         <li><a href="|8|">8</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|6|">Next &rarr;</a></li>
+        <li class="next"><a href="|6|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF
@@ -159,7 +159,7 @@ EOF
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|96|">&larr; Previous</a></li>
+        <li class="prev"><a href="|96|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|94|">94</a></li>
@@ -169,7 +169,7 @@ EOF
         <li><a href="|98|">98</a></li>
         <li><a href="|99|">99</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|98|">Next &rarr;</a></li>
+        <li class="next"><a href="|98|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF
@@ -186,7 +186,7 @@ EOF
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|95|">&larr; Previous</a></li>
+        <li class="prev"><a href="|95|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|93|">93</a></li>
@@ -197,7 +197,7 @@ EOF
         <li><a href="|98|">98</a></li>
         <li><a href="|99|">99</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|97|">Next &rarr;</a></li>
+        <li class="next"><a href="|97|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF
@@ -214,7 +214,7 @@ EOF
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|9|">&larr; Previous</a></li>
+        <li class="prev"><a href="|9|" rel="prev">&larr; Previous</a></li>
         <li><a href="|1|">1</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|8|">8</a></li>
@@ -224,7 +224,7 @@ EOF
         <li><a href="|12|">12</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|11|">Next &rarr;</a></li>
+        <li class="next"><a href="|11|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF
@@ -244,7 +244,7 @@ EOF
         $this->assertRenderedView(<<<EOF
 <div class="pagination">
     <ul>
-        <li class="prev"><a href="|9|">Anterior</a></li>
+        <li class="prev"><a href="|9|" rel="prev">Anterior</a></li>
         <li><a href="|1|">1</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|7|">7</a></li>
@@ -256,7 +256,7 @@ EOF
         <li><a href="|13|">13</a></li>
         <li class="disabled"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="next"><a href="|11|">Siguiente</a></li>
+        <li class="next"><a href="|11|" rel="next">Siguiente</a></li>
     </ul>
 </div>
 EOF
@@ -290,7 +290,7 @@ EOF
         <li><a href="|7|">7</a></li>
         <li class="puntos"><a href="#">&hellip;</a></li>
         <li><a href="|100|">100</a></li>
-        <li class="siguiente"><a href="|2|">Next &rarr;</a></li>
+        <li class="siguiente"><a href="|2|" rel="next">Next &rarr;</a></li>
     </ul>
 </div>
 EOF


### PR DESCRIPTION
Since september 2011, the usage of elements rel=”next” and rel=”prev” is recommended by Google for pagination crawling.
http://googlewebmastercentral.blogspot.fr/2011/09/pagination-with-relnext-and-relprev.html

It is a WHATWG specification too: http://www.whatwg.org/specs/web-apps/current-work/multipage/links.html#sequential-link-types
