### PR TITLE
Added helper methods to OutOfRangeCurrentPageException

### DIFF
--- a/src/Pagerfanta/Exception/OutOfRangeCurrentPageException.php
+++ b/src/Pagerfanta/Exception/OutOfRangeCurrentPageException.php
@@ -18,4 +18,38 @@ namespace Pagerfanta\Exception;
  */
 class OutOfRangeCurrentPageException extends NotValidCurrentPageException
 {
+    private $currentPage;
+    private $maxAllowedPage;
+
+    /**
+     * @return null|integer
+     */
+    public function getCurrentPage()
+    {
+        return $this->currentPage;
+    }
+
+    /**
+     * @param integer $page
+     */
+    public function setCurrentPage($page)
+    {
+        $this->currentPage = $page;
+    }
+
+    /**
+     * @return null|integer
+     */
+    public function getMaxAllowedPage()
+    {
+        return $this->maxAllowedPage;
+    }
+
+    /**
+     * @param integer $page
+     */
+    public function setMaxAllowedPage($page)
+    {
+        $this->maxAllowedPage = $page;
+    }
 }

--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -259,7 +259,11 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
             return $this->getNbPages();
         }
 
-        throw new OutOfRangeCurrentPageException(sprintf('Page "%d" does not exist. The currentPage must be inferior to "%d"', $currentPage, $this->getNbPages()));
+        $e = new OutOfRangeCurrentPageException(sprintf('Page "%d" does not exist. The currentPage must be inferior to "%d"', $currentPage, $this->getNbPages()));
+        $e->setCurrentPage($currentPage);
+        $e->setMaxAllowedPage($this->getNbPages());
+
+        throw $e;
     }
 
     private function resetForCurrentPageChange()


### PR DESCRIPTION
Use case for Symfony2:

``` php
try {
    $results = new Pagerfanta(new DoctrineORMAdapter($repository->findAll()));
    $results->setMaxPerPage($request->get('per_page', 24));
    $results->setCurrentPage($request->get('page', 1));
} catch (OutOfRangeCurrentPageException $e) {
    $query         = $request->query->all();
    $query['page'] = $e->getMaxAllowedPage();

    return $this->redirect($this->generateUrl('list', $query));
}
```

This helps i.e. when Google Bot indexed bigger max page than it's allowed now, and we **don't** want to allow those old pages to exist in index (current approach with hidding and replacing, still holds old "broken" data in URL: `Pagerfanta::setNormalizeOutOfRangePages()` & `Pagerfanta::setAllowOutOfRangePages()`).
