### PR TITLE
Removed the dev requirement of doctrine/mongodb-odm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ matrix:
 services: mongodb
 
 before_install:
+  # Add the MongoDB ODM when we can fulfil its ext-mongo dependency
   - 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ "$TRAVIS_PHP_VERSION" = "hhvm" ]; then grep -v "doctrine/mongodb-odm" composer.json > composer.json.new && mv composer.json.new composer.json; fi'
+  - 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require doctrine/mongodb-odm "~1.0@dev" --dev --no-update; fi'
   # Force using dev versions for HHVM as the Doctrine HHVM support is not yet released
   - 'if [[ "$COMPOSER_STABILITY" == "dev" || "$TRAVIS_PHP_VERSION" = "hhvm" ]]; then sed -i ''s/"pagerfanta\/pagerfanta"/"pagerfanta\/pagerfanta","minimum-stability": "dev"/g'' composer.json; fi'
   - sh -c "if [ $DOCTRINE_ORM_VERSION ]; then composer require doctrine/orm:${DOCTRINE_ORM_VERSION} --dev --no-update; fi"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "doctrine/orm": "~2.3",
         "mandango/mandango": "~1.0@dev",
         "mandango/mondator": "~1.0@dev",
-        "doctrine/mongodb-odm": "~1.0@dev",
         "jmikola/geojson": "~1.0",
         "doctrine/phpcr-odm": "1.*",
         "propel/propel1": "~1.6",


### PR DESCRIPTION
This package is now added dynamically on Travis for supported PHP versions (instead of being removed for HHVM). This avoids having a dependency to ext-mongo when installing the dev dependencies of the library, making it easier to run the testsuite for contributors.
This will also fix it for Scrutinizer as it does not have ext-mongo. Closes #152 
