### PR TITLE
Make tests compatible also with PHPUnit 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4",
+        "phpunit/phpunit": "~4 | ~5",
         "doctrine/orm": "~2.3",
         "mandango/mandango": "~1.0@dev",
         "mandango/mondator": "~1.0@dev",

--- a/tests/Pagerfanta/Tests/Adapter/DoctrineSelectableAdapterTest.php
+++ b/tests/Pagerfanta/Tests/Adapter/DoctrineSelectableAdapterTest.php
@@ -36,7 +36,7 @@ class DoctrineSelectableAdapterTest extends \PHPUnit_Framework_TestCase
 
     private function createSelectableMock()
     {
-        return $this->getMock('Doctrine\Common\Collections\Selectable');
+        return $this->getMockBuilder('Doctrine\Common\Collections\Selectable')->getMock();
     }
 
     private function createCriteria()
@@ -71,7 +71,7 @@ class DoctrineSelectableAdapterTest extends \PHPUnit_Framework_TestCase
 
     private function createCollectionMock()
     {
-        return $this->getMock('Doctrine\Common\Collections\Collection');
+        return $this->getMockBuilder('Doctrine\Common\Collections\Collection')->getMock();
     }
 
     public function testGetSlice()

--- a/tests/Pagerfanta/Tests/Adapter/SolariumAdapterTest.php
+++ b/tests/Pagerfanta/Tests/Adapter/SolariumAdapterTest.php
@@ -214,7 +214,7 @@ abstract class SolariumAdapterTest extends \PHPUnit_Framework_TestCase
 
     private function createQueryMock()
     {
-        return $this->getMock($this->getQueryClass());
+        return $this->getMockBuilder($this->getQueryClass())->getMock();
     }
 
     private function createQueryStub()

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -29,7 +29,7 @@ class PagerfantaTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->adapter = $this->getMock('Pagerfanta\Adapter\AdapterInterface');
+        $this->adapter = $this->getMockBuilder('Pagerfanta\Adapter\AdapterInterface')->getMock();
         $this->pagerfanta = new Pagerfanta($this->adapter);
     }
 

--- a/tests/Pagerfanta/Tests/View/OptionableViewTest.php
+++ b/tests/Pagerfanta/Tests/View/OptionableViewTest.php
@@ -18,7 +18,7 @@ class OptionableViewTest extends \PHPUnit_Framework_TestCase
 
     private function createPagerfantaMock()
     {
-        return $this->getMock('Pagerfanta\PagerfantaInterface');
+        return $this->getMockBuilder('Pagerfanta\PagerfantaInterface')->getMock();
     }
 
     private function createRouteGenerator()
@@ -52,7 +52,7 @@ class OptionableViewTest extends \PHPUnit_Framework_TestCase
 
     private function createViewMock($expectedOptions)
     {
-        $view = $this->getMock('Pagerfanta\View\ViewInterface');
+        $view = $this->getMockBuilder('Pagerfanta\View\ViewInterface')->getMock();
         $view
             ->expects($this->once())
             ->method('render')

--- a/tests/Pagerfanta/Tests/View/ViewFactoryTest.php
+++ b/tests/Pagerfanta/Tests/View/ViewFactoryTest.php
@@ -8,10 +8,10 @@ class ViewFactoryTest extends \PHPUnit_Framework_TestCase
 {
     public function testFactory()
     {
-        $view1 = $this->getMock('Pagerfanta\View\ViewInterface');
-        $view2 = $this->getMock('Pagerfanta\View\ViewInterface');
-        $view3 = $this->getMock('Pagerfanta\View\ViewInterface');
-        $view4 = $this->getMock('Pagerfanta\View\ViewInterface');
+        $view1 = $this->getMockBuilder('Pagerfanta\View\ViewInterface')->getMock();
+        $view2 = $this->getMockBuilder('Pagerfanta\View\ViewInterface')->getMock();
+        $view3 = $this->getMockBuilder('Pagerfanta\View\ViewInterface')->getMock();
+        $view4 = $this->getMockBuilder('Pagerfanta\View\ViewInterface')->getMock();
 
         $factory = new ViewFactory();
 

--- a/tests/Pagerfanta/Tests/View/ViewTestCase.php
+++ b/tests/Pagerfanta/Tests/View/ViewTestCase.php
@@ -26,7 +26,7 @@ abstract class ViewTestCase extends \PHPUnit_Framework_TestCase
 
     private function createAdapterMock()
     {
-        return $this->getMock('Pagerfanta\Adapter\AdapterInterface');
+        return $this->getMockBuilder('Pagerfanta\Adapter\AdapterInterface')->getMock();
     }
 
     /**


### PR DESCRIPTION
PHPUnit 5.4 [deprecated](https://github.com/sebastianbergmann/phpunit/wiki/Release-Announcement-for-PHPUnit-5.4.0) `$this->getMock()` method inside TestCase.

This change makes the code filly compatible with both PHPUnit 5.x and PHPUnit 4.x (thus maintaining PHP 5.3 compatibility).
