### PR TITLE
Added getter for Pagerfanta\View\Template\Template::$options

### DIFF
--- a/src/Pagerfanta/View/Template/Template.php
+++ b/src/Pagerfanta/View/Template/Template.php
@@ -36,6 +36,11 @@ abstract class Template implements TemplateInterface
         $this->options = array_merge($this->options, $options);
     }
 
+    public function getOptions()
+    {
+        return $this->options;
+    }
+    
     private function initializeOptions()
     {
         $this->options = static::$defaultOptions;


### PR DESCRIPTION
I'm implementing a view that fit with [domajax](http://domajax.fuz.org).

For this, I need to recover all options starting with `data-` in my view, and I can't do it as the `$options` is private in the extended template.