### PR TITLE
currentPageOutOfRange bug fix

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -258,7 +258,7 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
 
     private function currentPageOutOfRange($currentPage)
     {
-        return $currentPage > 1 && $currentPage > $this->getNbPages();
+        return $currentPage < 1 && $currentPage > $this->getNbPages();
     }
 
     /**


### PR DESCRIPTION
If page is greater than 1 throws currentPageOutOfRange error becouse the comparison is wrong, it need to be equal o more than 1 or less than max pages.