### PR TITLE
Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - hhvm
 
 matrix:
   include:
@@ -20,10 +19,9 @@ services: mongodb
 
 before_install:
   # Add the MongoDB ODM when we can fulfil its ext-mongo dependency
-  - 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi'
-  - 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then composer require doctrine/mongodb-odm "~1.0@dev" --dev --no-update; fi'
-  # Force using dev versions for HHVM as the Doctrine HHVM support is not yet released
-  - 'if [[ "$COMPOSER_STABILITY" == "dev" || "$TRAVIS_PHP_VERSION" = "hhvm" ]]; then sed -i ''s/"pagerfanta\/pagerfanta"/"pagerfanta\/pagerfanta","minimum-stability": "dev"/g'' composer.json; fi'
+  - 'echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini'
+  - 'composer require doctrine/mongodb-odm "~1.0@dev" --dev --no-update'
+  - 'if [[ "$COMPOSER_STABILITY" == "dev" ]]; then sed -i ''s/"pagerfanta\/pagerfanta"/"pagerfanta\/pagerfanta","minimum-stability": "dev"/g'' composer.json; fi'
   # Remove Propel2 dependency for unsupported php versions
   - 'if [ "$TRAVIS_PHP_VERSION" == "5.3" ] ; then composer remove propel/propel --dev --no-update; fi'
   - sh -c "if [ $DOCTRINE_ORM_VERSION ]; then composer require doctrine/orm:${DOCTRINE_ORM_VERSION} --dev --no-update; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,17 @@
 language: php
 
+dist: trusty
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
 
 matrix:
   include:
+    # PHP 5.3 doesn't install on Trusty on Travis: https://github.com/travis-ci/travis-ci/issues/8219
+    - php: 5.3
+      dist: precise
     # older releases
     - php: 5.5
       env: SOLARIUM_VERSION=2.* DOCTRINE_ORM_VERSION=2.3.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - php: 5.5
       env: SOLARIUM_VERSION=2.* DOCTRINE_ORM_VERSION=2.3.*
     # dev versions
-    - php: 5.5
+    - php: 5.6
       env: COMPOSER_STABILITY=dev
 
 services: mongodb


### PR DESCRIPTION
* Remove HHVM from Travis build (fixes #232)
* Switch to Trusty (14.04) on Travis but keep 5.3 on Precise (12.04)
* Test dev against PHP 5.6; 5.5 is EOL
