### PR TITLE
Add method to identify which page the Nth item is on

### DIFF
--- a/src/Pagerfanta/Exception/NotIntegerException.php
+++ b/src/Pagerfanta/Exception/NotIntegerException.php
@@ -16,6 +16,6 @@ namespace Pagerfanta\Exception;
  *
  * @author Alexandre Fayeaux <alexandre.fayeaux@gmail.com>
  */
-class NotIntegerItemException extends InvalidArgumentException
+class NotIntegerException extends InvalidArgumentException
 {
 }

--- a/src/Pagerfanta/Exception/NotIntegerItemException.php
+++ b/src/Pagerfanta/Exception/NotIntegerItemException.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Pagerfanta package.
+ *
+ * (c) Pablo Díez <pablodip@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Pagerfanta\Exception;
+
+/**
+ * NotIntegerItemException.
+ *
+ * @author Alexandre Fayeaux <alexandre.fayeaux@gmail.com>
+ */
+class NotIntegerItemException extends InvalidArgumentException
+{
+}

--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -11,10 +11,11 @@
 
 namespace Pagerfanta;
 
+use OutOfBoundsException;
 use Pagerfanta\Adapter\AdapterInterface;
 use Pagerfanta\Exception\LogicException;
 use Pagerfanta\Exception\NotBooleanException;
-use Pagerfanta\Exception\NotIntegerItemException;
+use Pagerfanta\Exception\NotIntegerException;
 use Pagerfanta\Exception\NotIntegerMaxPerPageException;
 use Pagerfanta\Exception\LessThan1MaxPerPageException;
 use Pagerfanta\Exception\NotIntegerCurrentPageException;
@@ -510,11 +511,15 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
     public function getPageNumberForItemAtPosition($position)
     {
         if (!is_int($position)) {
-            throw new NotIntegerItemException();
+            throw new NotIntegerException();
         }
 
         if ($this->getNbResults() < $position) {
-            throw new LogicException('Searched item does not exist');
+            throw new OutOfBoundsException(sprintf(
+                'Item requested at position %d, but there are only %d items.',
+                $position,
+                $this->getNbResults()
+            ));
         }
 
         return (int) ceil($position/$this->getMaxPerPage());

--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -501,22 +501,22 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
     }
 
     /**
-     * Get page number of a specific item
+     * Get page number of the item at specified position (1-based index)
      *
-     * @param integer $item
+     * @param integer $position
      *
      * @return integer
      */
-    public function getPageNumberForItem($item)
+    public function getPageNumberForItemAtPosition($position)
     {
-        if (!is_int($item)) {
+        if (!is_int($position)) {
             throw new NotIntegerItemException();
         }
 
-        if ($this->getNbResults() < $item) {
+        if ($this->getNbResults() < $position) {
             throw new LogicException('Searched item does not exist');
         }
 
-        return (int) ceil($item/$this->getMaxPerPage());
+        return (int) ceil($position/$this->getMaxPerPage());
     }
 }

--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -14,6 +14,7 @@ namespace Pagerfanta;
 use Pagerfanta\Adapter\AdapterInterface;
 use Pagerfanta\Exception\LogicException;
 use Pagerfanta\Exception\NotBooleanException;
+use Pagerfanta\Exception\NotIntegerItemException;
 use Pagerfanta\Exception\NotIntegerMaxPerPageException;
 use Pagerfanta\Exception\LessThan1MaxPerPageException;
 use Pagerfanta\Exception\NotIntegerCurrentPageException;
@@ -497,5 +498,25 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
     private function needsToIntegerConversion($value)
     {
         return (is_string($value) || is_float($value)) && (int) $value == $value;
+    }
+
+    /**
+     * Get page number of a specific item
+     *
+     * @param integer $item
+     *
+     * @return integer
+     */
+    public function getPageNumberForItem($item)
+    {
+        if (!is_int($item)) {
+            throw new NotIntegerItemException();
+        }
+
+        if ($this->getNbResults() < $item) {
+            throw new LogicException('Searched item does not exist');
+        }
+
+        return (int) ceil($item/$this->getMaxPerPage());
     }
 }

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -703,7 +703,7 @@ class PagerfantaTest extends TestCase
     }
 
     /**
-     * @expectedException Pagerfanta\Exception\NotIntegerItemException
+     * @expectedException Pagerfanta\Exception\NotIntegerException
      */
     public function testGetPageNumberForItemShouldThrowANotIntegerItemExceptionIfTheItemIsNotAnInteger()
     {
@@ -713,7 +713,7 @@ class PagerfantaTest extends TestCase
     }
 
     /**
-     * @expectedException Pagerfanta\Exception\LogicException
+     * @expectedException \OutOfBoundsException
      */
     public function testGetPageNumberForItemShouldThrowALogicExceptionIfTheItemIsMoreThanNbPage()
     {

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -693,4 +693,32 @@ class PagerfantaTest extends TestCase
         $callback();
         $this->assertSame($currentPageResults1, $this->pagerfanta->getCurrentPageResults());
     }
+
+    public function testGetPageNumberForItemShouldReturnTheGoodPage()
+    {
+        $this->setAdapterNbResultsAny(100);
+        $this->pagerfanta->setMaxPerPage(10);
+
+        $this->assertEquals(4, $this->pagerfanta->getPageNumberForItem(35));
+    }
+
+    /**
+     * @expectedException Pagerfanta\Exception\NotIntegerItemException
+     */
+    public function testGetPageNumberForItemShouldThrowANotIntegerItemExceptionIfTheItemIsNotAnInteger()
+    {
+        $this->setAdapterNbResultsAny(100);
+
+        $this->pagerfanta->getPageNumberForItem('foo');
+    }
+
+    /**
+     * @expectedException Pagerfanta\Exception\LogicException
+     */
+    public function testGetPageNumberForItemShouldThrowALogicExceptionIfTheItemIsMoreThanNbPage()
+    {
+        $this->setAdapterNbResultsAny(100);
+
+        $this->pagerfanta->getPageNumberForItem(101);
+    }
 }

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -699,7 +699,7 @@ class PagerfantaTest extends TestCase
         $this->setAdapterNbResultsAny(100);
         $this->pagerfanta->setMaxPerPage(10);
 
-        $this->assertEquals(4, $this->pagerfanta->getPageNumberForItem(35));
+        $this->assertEquals(4, $this->pagerfanta->getPageNumberForItemAtPosition(35));
     }
 
     /**
@@ -709,7 +709,7 @@ class PagerfantaTest extends TestCase
     {
         $this->setAdapterNbResultsAny(100);
 
-        $this->pagerfanta->getPageNumberForItem('foo');
+        $this->pagerfanta->getPageNumberForItemAtPosition('foo');
     }
 
     /**
@@ -719,6 +719,6 @@ class PagerfantaTest extends TestCase
     {
         $this->setAdapterNbResultsAny(100);
 
-        $this->pagerfanta->getPageNumberForItem(101);
+        $this->pagerfanta->getPageNumberForItemAtPosition(101);
     }
 }


### PR DESCRIPTION
Add method to identify which page the Nth item is on.

Fixes #234.

Usage : 
``` php
$pagerfanta->getPageNumberForItem(35)
```
This should return `4` if there are `10` items per page and more than `35` items.