### PR TITLE
Implement JsonSerializable

### DIFF
--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -494,7 +494,12 @@ class Pagerfanta implements \Countable, \IteratorAggregate, \JsonSerializable, P
      */
     public function jsonSerialize()
     {
-        return $this->getCurrentPageResults();
+        $results = $this->getCurrentPageResults();
+        if ($results instanceof \Traversable) {
+            return iterator_to_array($results);
+        }
+        
+        return $results;
     }
 
     private function toInteger($value)

--- a/src/Pagerfanta/Pagerfanta.php
+++ b/src/Pagerfanta/Pagerfanta.php
@@ -27,7 +27,7 @@ use Pagerfanta\Exception\OutOfRangeCurrentPageException;
  *
  * @author Pablo Díez <pablodip@gmail.com>
  */
-class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
+class Pagerfanta implements \Countable, \IteratorAggregate, \JsonSerializable, PagerfantaInterface
 {
     private $adapter;
     private $allowOutOfRangePages;
@@ -460,7 +460,7 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
     /**
      * Implements the \Countable interface.
      *
-     * Return integer The number of results.
+     * @return integer The number of results.
      */
     public function count()
     {
@@ -470,7 +470,7 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
     /**
      * Implements the \IteratorAggregate interface.
      *
-     * Returns an \ArrayIterator instance with the current results.
+     * @return \ArrayIterator instance with the current results.
      */
     public function getIterator()
     {
@@ -485,6 +485,16 @@ class Pagerfanta implements \Countable, \IteratorAggregate, PagerfantaInterface
         }
 
         return new \ArrayIterator($results);
+    }
+
+    /**
+     * Implements the \JsonSerializable interface.
+     *
+     * @return array current page results
+     */
+    public function jsonSerialize()
+    {
+        return $this->getCurrentPageResults();
     }
 
     private function toInteger($value)

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -658,6 +658,31 @@ class PagerfantaTest extends TestCase
         $expected = new \ArrayIterator($currentPageResults);
         $this->assertEquals($expected, $this->pagerfanta->getIterator());
     }
+    
+    public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfItIsAnIterator()
+    {
+        $currentPageResults = new \ArrayIterator(array('foo'));
+        $this->setAdapterGetSlice($currentPageResults);
+        
+        $expected = array('foo');
+        $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
+    }
+    public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfItIsAnIteratorAggregate()
+    {
+        $currentPageResults = new IteratorAggregate();
+        $this->setAdapterGetSlice($currentPageResults);
+        
+        $expected = iterator_to_array($currentPageResults);
+        $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
+    }
+    public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfCurrentPageResultsIsAnArray()
+    {
+        $currentPageResults = array('foo', 'bar');
+        $this->setAdapterGetSlice($currentPageResults);
+        
+        $expected = $currentPageResults;
+        $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
+    }
 
     private function setAdapterGetSlice($currentPageResults)
     {

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -658,30 +658,50 @@ class PagerfantaTest extends TestCase
         $expected = new \ArrayIterator($currentPageResults);
         $this->assertEquals($expected, $this->pagerfanta->getIterator());
     }
-    
+
     public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfItIsAnIterator()
     {
         $currentPageResults = new \ArrayIterator(array('foo'));
         $this->setAdapterGetSlice($currentPageResults);
-        
+
         $expected = array('foo');
         $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
     }
+
     public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfItIsAnIteratorAggregate()
     {
         $currentPageResults = new IteratorAggregate();
         $this->setAdapterGetSlice($currentPageResults);
-        
+
         $expected = iterator_to_array($currentPageResults);
         $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
     }
+
     public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfCurrentPageResultsIsAnArray()
     {
         $currentPageResults = array('foo', 'bar');
         $this->setAdapterGetSlice($currentPageResults);
-        
+
         $expected = $currentPageResults;
         $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
+    }
+
+    public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfCurrentPageResultsIsAnArray()
+    {
+        $currentPageResults = array('foo', 'bar');
+        $this->setAdapterGetSlice($currentPageResults);
+
+        $expected = $currentPageResults;
+        $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
+    }
+
+    public function testJsonSerializeIsUsedOnJsonEncode()
+    {
+        $currentPageResults = array('foo', 'bar');
+        $this->setAdapterGetSlice($currentPageResults);
+
+        $expected = json_encode($currentPageResults);
+        $this->assertSame($expected, json_encode($this->pagerfanta));
     }
 
     private function setAdapterGetSlice($currentPageResults)

--- a/tests/Pagerfanta/Tests/PagerfantaTest.php
+++ b/tests/Pagerfanta/Tests/PagerfantaTest.php
@@ -686,15 +686,6 @@ class PagerfantaTest extends TestCase
         $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
     }
 
-    public function testJsonSerializeShouldReturnAnArrayOfCurrentPageResultsIfCurrentPageResultsIsAnArray()
-    {
-        $currentPageResults = array('foo', 'bar');
-        $this->setAdapterGetSlice($currentPageResults);
-
-        $expected = $currentPageResults;
-        $this->assertSame($expected, $this->pagerfanta->jsonSerialize());
-    }
-
     public function testJsonSerializeIsUsedOnJsonEncode()
     {
         $currentPageResults = array('foo', 'bar');


### PR DESCRIPTION
It allows Pagerfanta instances to be JSON-encoded:
```php
json_encode($pagerfanta);
```

See:
https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle/issues/165
https://github.com/willdurand/Hateoas/issues/128