### PR TITLE
Simplify travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,6 @@ php:
 
 services: mongodb
 
-before_install:
-  - 'if [[ "$COMPOSER_STABILITY" == "dev" ]]; then sed -i ''s/"pagerfanta\/pagerfanta"/"pagerfanta\/pagerfanta","minimum-stability": "dev"/g'' composer.json; fi'
-  - sh -c "if [ $DOCTRINE_ORM_VERSION ]; then composer require doctrine/orm:${DOCTRINE_ORM_VERSION} --dev --no-update; fi"
-  - sh -c "if [ $SOLARIUM_VERSION ]; then composer require solarium/solarium:${SOLARIUM_VERSION} --dev --no-update; fi"
-
 install:
   - composer install
 


### PR DESCRIPTION
All steps in the `before_install` were there for older php versions which are no longer supported