### PR TITLE
Update phpunit requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6",
+        "phpunit/phpunit": "^6.5",
         "doctrine/orm": "~2.3",
         "mandango/mandango": "~1.0@dev",
         "mandango/mondator": "~1.0@dev",


### PR DESCRIPTION
No reason to 'support' lower phpunit versions, especially since we can use this version with php requirements