### PR TITLE
Fixed: Attempted to call an undefined method named "count" of class " Doctrine\ODM\MongoDB\Query\Query". in DoctrineODMMongoDBAdapter

### DIFF
--- a/src/Pagerfanta/Adapter/DoctrineODMMongoDBAdapter.php
+++ b/src/Pagerfanta/Adapter/DoctrineODMMongoDBAdapter.php
@@ -47,7 +47,14 @@ class DoctrineODMMongoDBAdapter implements AdapterInterface
      */
     public function getNbResults()
     {
-        return $this->queryBuilder->getQuery()->count();
+        $qb = clone $this->queryBuilder;
+
+        return $qb
+            ->limit(0)
+            ->skip(0)
+            ->count()
+            ->getQuery()
+            ->execute();
     }
 
     /**


### PR DESCRIPTION
Problem:
When using DoctrineODMMongoDBAdapter and calling any method which uses Pagerfanta::getNbResults receiving error: ttempted to call an undefined method named "count" of class " Doctrine\ODM\MongoDB\Query\Query".