### PR TITLE
[ElasticaAdapter] use count() instead search() for getNbResult()

### DIFF
--- a/src/Pagerfanta/Adapter/ElasticaAdapter.php
+++ b/src/Pagerfanta/Adapter/ElasticaAdapter.php
@@ -60,7 +60,7 @@ class ElasticaAdapter implements AdapterInterface
     public function getNbResults()
     {
         if (!$this->resultSet) {
-            $totalHits = $this->searchable->search($this->query, $this->options)->getTotalHits();
+            $totalHits = $this->searchable->count($this->query);
         } else {
             $totalHits = $this->resultSet->getTotalHits();
         }


### PR DESCRIPTION
`getNbResult()` methods execute `search()`

-> use the `count()` method for performance gain _(this add `"size": 0` to ES query)_

***

cf: https://github.com/whiteoctober/Pagerfanta/pull/213